### PR TITLE
Fix : SearchByActorAsync call undefined endpoint

### DIFF
--- a/TMdbEasy Tests/APItests/MovieApiTest.cs
+++ b/TMdbEasy Tests/APItests/MovieApiTest.cs
@@ -59,17 +59,6 @@ namespace TMdbEasy_Tests.APItests
         [Category("MovieApi")]
         public class SearchByActorAsync
         {
-            [TestCase("125")]
-            public void IncorrectId_ThrowsException(string id, string language = "en")
-            {
-                //arrange
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
-                var d = obj.GetApi<IMovieApi>().Value;
-                //assert
-                Assert.Throws<AggregateException>(() => {
-                    SUT.TmdbObjects.Movies.MovieList tit = d.SearchByActorAsync(id).Result; });
-            }
-
             [TestCase("Brad Pitt")]
             public void FamousActor_ReturnResults(string actorName)
             {

--- a/TMdbEasy Tests/APItests/MovieApiTest.cs
+++ b/TMdbEasy Tests/APItests/MovieApiTest.cs
@@ -69,6 +69,15 @@ namespace TMdbEasy_Tests.APItests
                 Assert.Throws<AggregateException>(() => {
                     SUT.TmdbObjects.Movies.MovieList tit = d.SearchByActorAsync(id).Result; });
             }
+
+            [TestCase("Brad Pitt")]
+            public void FamousActor_ReturnResults(string actorName)
+            {
+                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var d = obj.GetApi<IMovieApi>().Value;
+
+                CollectionAssert.IsNotEmpty(d.SearchByActorAsync(actorName).Result.Results);
+            }
         }
     }
 }

--- a/TMdbEasy/ApiObjects/MovieApi.cs
+++ b/TMdbEasy/ApiObjects/MovieApi.cs
@@ -134,7 +134,7 @@ namespace TMdbEasy.ApiObjects
         //not tested
         public async Task<MovieList> SearchByActorAsync(string query, string language = "en", int page = 1, bool include_adult = false, string region = "US")
         {
-            var content = await CallApiAsync($"{Url}search/people?api_key={ApiKey}&language={language}&query={query}" +
+            var content = await CallApiAsync($"{Url}search/person?api_key={ApiKey}&language={language}&query={query}" +
                 $"&page={page}&include_adult={include_adult}&region={region}").ConfigureAwait(false);
 
             return DeserializeJson<MovieList>(content);


### PR DESCRIPTION
There is a little typo in the `search/person` aka SearchByActorAsync query builder function and with this PR it will be fixed.

(An integration test added and removed one which is unnecessary because when You pass `int` (for ex.: an ID) instead of `string` it returned an empty result for me. Before this PR it returned an Exception because it was an invalid endpoint).