### PR TITLE
Improve test performance

### DIFF
--- a/TMdbEasy Tests/APItests/ChangesApiTest.cs
+++ b/TMdbEasy Tests/APItests/ChangesApiTest.cs
@@ -19,10 +19,8 @@ namespace TMdbEasy_Tests.APItests
             [TestCase("20/02/2018", "2/02/2018")]
             public void IncorrectDate_ThrowsException(string end_date = null, string start_date = null, int page = 1)
             {
-                //arrange
-                var obj = new SUT.EasyClient(Constants.ValidApiKey);
-                var d = obj.GetApi<IChangesApi>().Value;
-                //assert
+                var d = Constants.SecureTestClient.GetApi<IChangesApi>().Value;
+
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Changes.ChangeList ch
                     = d.GetMovieChangeListAsync(end_date,start_date,page).Result; });
             }
@@ -36,10 +34,8 @@ namespace TMdbEasy_Tests.APItests
             [TestCase("20/02/2018", "24/022018")]
             public void IncorrectDate_ThrowsException(string end_date = null, string start_date = null, int page = 1)
             {
-                //arrange
-                var obj = new SUT.EasyClient(Constants.ValidApiKey);
-                var d = obj.GetApi<IChangesApi>().Value;
-                //assert
+                var d = Constants.SecureTestClient.GetApi<IChangesApi>().Value;
+
                 Assert.Throws<AggregateException>(() =>
                 {
                     SUT.TmdbObjects.Changes.ChangeList ch
@@ -56,10 +52,8 @@ namespace TMdbEasy_Tests.APItests
             [TestCase("20/02/2018", "2602/2018")]
             public void IncorrectDate_ThrowsException(string end_date = null, string start_date = null, int page = 1)
             {
-                //arrange
-                var obj = new SUT.EasyClient(Constants.ValidApiKey);
-                var d = obj.GetApi<IChangesApi>().Value;
-                //assert
+                var d = Constants.SecureTestClient.GetApi<IChangesApi>().Value;
+
                 Assert.Throws<AggregateException>(() =>
                 {
                     SUT.TmdbObjects.Changes.ChangeList ch

--- a/TMdbEasy Tests/APItests/ChangesApiTest.cs
+++ b/TMdbEasy Tests/APItests/ChangesApiTest.cs
@@ -20,7 +20,7 @@ namespace TMdbEasy_Tests.APItests
             public void IncorrectDate_ThrowsException(string end_date = null, string start_date = null, int page = 1)
             {
                 //arrange
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var obj = new SUT.EasyClient(Constants.ValidApiKey);
                 var d = obj.GetApi<IChangesApi>().Value;
                 //assert
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Changes.ChangeList ch
@@ -37,7 +37,7 @@ namespace TMdbEasy_Tests.APItests
             public void IncorrectDate_ThrowsException(string end_date = null, string start_date = null, int page = 1)
             {
                 //arrange
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var obj = new SUT.EasyClient(Constants.ValidApiKey);
                 var d = obj.GetApi<IChangesApi>().Value;
                 //assert
                 Assert.Throws<AggregateException>(() =>
@@ -57,7 +57,7 @@ namespace TMdbEasy_Tests.APItests
             public void IncorrectDate_ThrowsException(string end_date = null, string start_date = null, int page = 1)
             {
                 //arrange
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var obj = new SUT.EasyClient(Constants.ValidApiKey);
                 var d = obj.GetApi<IChangesApi>().Value;
                 //assert
                 Assert.Throws<AggregateException>(() =>

--- a/TMdbEasy Tests/APItests/CollectionApiTest.cs
+++ b/TMdbEasy Tests/APItests/CollectionApiTest.cs
@@ -19,10 +19,8 @@ namespace TMdbEasy_Tests.APItests
             [TestCase(296096321)]
             public void IncorrectId_ThrowsException(int id, string language = "en")
             {
-                //arrange
-                var obj = new SUT.EasyClient(Constants.ValidApiKey);
-                var d = obj.GetApi<ICollectionApi>().Value;
-                //assert
+                var d = Constants.SecureTestClient.GetApi<ICollectionApi>().Value;
+
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Collection.Collections col = d.GetDetailsAsync(id, language).Result; });
             }
         }
@@ -34,10 +32,8 @@ namespace TMdbEasy_Tests.APItests
             [TestCase(296096321)]
             public void IncorrectId_ThrowsException(int id, string language = "en")
             {
-                //arrange
-                var obj = new SUT.EasyClient(Constants.ValidApiKey);
-                var d = obj.GetApi<ICollectionApi>().Value;
-                //assert
+                var d = Constants.SecureTestClient.GetApi<ICollectionApi>().Value;
+
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Images.Images ima = d.GetImagesAsync(id, language).Result; });
             }
         }

--- a/TMdbEasy Tests/APItests/CollectionApiTest.cs
+++ b/TMdbEasy Tests/APItests/CollectionApiTest.cs
@@ -20,7 +20,7 @@ namespace TMdbEasy_Tests.APItests
             public void IncorrectId_ThrowsException(int id, string language = "en")
             {
                 //arrange
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var obj = new SUT.EasyClient(Constants.ValidApiKey);
                 var d = obj.GetApi<ICollectionApi>().Value;
                 //assert
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Collection.Collections col = d.GetDetailsAsync(id, language).Result; });
@@ -35,7 +35,7 @@ namespace TMdbEasy_Tests.APItests
             public void IncorrectId_ThrowsException(int id, string language = "en")
             {
                 //arrange
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var obj = new SUT.EasyClient(Constants.ValidApiKey);
                 var d = obj.GetApi<ICollectionApi>().Value;
                 //assert
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Images.Images ima = d.GetImagesAsync(id, language).Result; });

--- a/TMdbEasy Tests/APItests/CompaniesApiTest.cs
+++ b/TMdbEasy Tests/APItests/CompaniesApiTest.cs
@@ -20,7 +20,7 @@ namespace TMdbEasy_Tests.APItests
             public void IncorrectId_ThrowsException(int id)
             {
                 //arrange
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var obj = new SUT.EasyClient(Constants.ValidApiKey);
                 var d = obj.GetApi<ICompaniesApi>().Value;
                 //assert
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Companies.CompanyDetails cd = d.GetDetailsAsync(id).Result; });
@@ -35,7 +35,7 @@ namespace TMdbEasy_Tests.APItests
             public void IncorrectId_ThrowsException(int id, string language = "en")
             {
                 //arrange
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var obj = new SUT.EasyClient(Constants.ValidApiKey);
                 var d = obj.GetApi<ICompaniesApi>().Value;
                 //assert
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Companies.MoviesByCompany mbc = d.GetMoviesAsync(id, language).Result; });

--- a/TMdbEasy Tests/APItests/CompaniesApiTest.cs
+++ b/TMdbEasy Tests/APItests/CompaniesApiTest.cs
@@ -19,10 +19,8 @@ namespace TMdbEasy_Tests.APItests
             [TestCase(296096321)]
             public void IncorrectId_ThrowsException(int id)
             {
-                //arrange
-                var obj = new SUT.EasyClient(Constants.ValidApiKey);
-                var d = obj.GetApi<ICompaniesApi>().Value;
-                //assert
+                var d = Constants.SecureTestClient.GetApi<ICompaniesApi>().Value;
+
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Companies.CompanyDetails cd = d.GetDetailsAsync(id).Result; });
             }
         }
@@ -34,10 +32,8 @@ namespace TMdbEasy_Tests.APItests
             [TestCase(254665465)]
             public void IncorrectId_ThrowsException(int id, string language = "en")
             {
-                //arrange
-                var obj = new SUT.EasyClient(Constants.ValidApiKey);
-                var d = obj.GetApi<ICompaniesApi>().Value;
-                //assert
+                var d = Constants.SecureTestClient.GetApi<ICompaniesApi>().Value;
+
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Companies.MoviesByCompany mbc = d.GetMoviesAsync(id, language).Result; });
             }
         }

--- a/TMdbEasy Tests/APItests/CreditApiTest.cs
+++ b/TMdbEasy Tests/APItests/CreditApiTest.cs
@@ -19,10 +19,8 @@ namespace TMdbEasy_Tests.APItests
             [TestCase(296096321)]
             public void IncorrectId_ThrowsException(int id)
             {
-                //arrange
-                var obj = new SUT.EasyClient(Constants.ValidApiKey);
-                var d = obj.GetApi<ICreditApi>().Value;
-                //assert
+                var d = Constants.SecureTestClient.GetApi<ICreditApi>().Value;
+
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Other.Credits cr = d.GetDetailsAsync(id).Result; });
             }
         }

--- a/TMdbEasy Tests/APItests/CreditApiTest.cs
+++ b/TMdbEasy Tests/APItests/CreditApiTest.cs
@@ -20,7 +20,7 @@ namespace TMdbEasy_Tests.APItests
             public void IncorrectId_ThrowsException(int id)
             {
                 //arrange
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var obj = new SUT.EasyClient(Constants.ValidApiKey);
                 var d = obj.GetApi<ICreditApi>().Value;
                 //assert
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Other.Credits cr = d.GetDetailsAsync(id).Result; });

--- a/TMdbEasy Tests/APItests/MovieApiTest.cs
+++ b/TMdbEasy Tests/APItests/MovieApiTest.cs
@@ -18,7 +18,7 @@ namespace TMdbEasy_Tests.APItests
             public void IncorrectId_ThrowsException(int id, string language = "en")
             {
                 //arrange
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var obj = new SUT.EasyClient(Constants.ValidApiKey);
                 var d = obj.GetApi<IMovieApi>().Value;
                 //assert
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Movies.MovieFullDetails mov = d.GetDetailsAsync(id).Result; });
@@ -33,7 +33,7 @@ namespace TMdbEasy_Tests.APItests
             public void IncorrectId_ThrowsException(int id, string language = "en")
             {
                 //arrange
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var obj = new SUT.EasyClient(Constants.ValidApiKey);
                 var d = obj.GetApi<IMovieApi>().Value;
                 //assert
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Images.Images ima = d.GetImagesAsync(id).Result; });
@@ -48,7 +48,7 @@ namespace TMdbEasy_Tests.APItests
             public void IncorrectId_ThrowsException(int id, string language = "en")
             {
                 //arrange
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var obj = new SUT.EasyClient(Constants.ValidApiKey);
                 var d = obj.GetApi<IMovieApi>().Value;
                 //assert
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Movies.AlternativeTitle tit = d.GetAlternativeTitlesAsync(id).Result; });
@@ -62,7 +62,7 @@ namespace TMdbEasy_Tests.APItests
             [TestCase("Brad Pitt")]
             public void FamousActor_ReturnResults(string actorName)
             {
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var obj = new SUT.EasyClient(Constants.ValidApiKey);
                 var d = obj.GetApi<IMovieApi>().Value;
 
                 CollectionAssert.IsNotEmpty(d.SearchByActorAsync(actorName).Result.Results);

--- a/TMdbEasy Tests/APItests/MovieApiTest.cs
+++ b/TMdbEasy Tests/APItests/MovieApiTest.cs
@@ -17,10 +17,8 @@ namespace TMdbEasy_Tests.APItests
             [TestCase(5018857)]
             public void IncorrectId_ThrowsException(int id, string language = "en")
             {
-                //arrange
-                var obj = new SUT.EasyClient(Constants.ValidApiKey);
-                var d = obj.GetApi<IMovieApi>().Value;
-                //assert
+                var d = Constants.SecureTestClient.GetApi<IMovieApi>().Value;
+
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Movies.MovieFullDetails mov = d.GetDetailsAsync(id).Result; });
             }
         }
@@ -32,10 +30,8 @@ namespace TMdbEasy_Tests.APItests
             [TestCase(296096321)]
             public void IncorrectId_ThrowsException(int id, string language = "en")
             {
-                //arrange
-                var obj = new SUT.EasyClient(Constants.ValidApiKey);
-                var d = obj.GetApi<IMovieApi>().Value;
-                //assert
+                var d = Constants.SecureTestClient.GetApi<IMovieApi>().Value;
+
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Images.Images ima = d.GetImagesAsync(id).Result; });
             }
         }
@@ -47,10 +43,8 @@ namespace TMdbEasy_Tests.APItests
             [TestCase(296096321)]
             public void IncorrectId_ThrowsException(int id, string language = "en")
             {
-                //arrange
-                var obj = new SUT.EasyClient(Constants.ValidApiKey);
-                var d = obj.GetApi<IMovieApi>().Value;
-                //assert
+                var d = Constants.SecureTestClient.GetApi<IMovieApi>().Value;
+
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Movies.AlternativeTitle tit = d.GetAlternativeTitlesAsync(id).Result; });
             }
         }
@@ -62,8 +56,7 @@ namespace TMdbEasy_Tests.APItests
             [TestCase("Brad Pitt")]
             public void FamousActor_ReturnResults(string actorName)
             {
-                var obj = new SUT.EasyClient(Constants.ValidApiKey);
-                var d = obj.GetApi<IMovieApi>().Value;
+                var d = Constants.SecureTestClient.GetApi<IMovieApi>().Value;
 
                 CollectionAssert.IsNotEmpty(d.SearchByActorAsync(actorName).Result.Results);
             }

--- a/TMdbEasy Tests/APItests/NetworkApiTest.cs
+++ b/TMdbEasy Tests/APItests/NetworkApiTest.cs
@@ -20,7 +20,7 @@ namespace TMdbEasy_Tests.APItests
             public void IncorrectId_ThrowsException(int id)
             {
                 //arrange
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var obj = new SUT.EasyClient(Constants.ValidApiKey);
                 var d = obj.GetApi<INetworksApi>().Value;
                 //assert
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Other.Network nt = d.GetDetailsAsync(id).Result; });

--- a/TMdbEasy Tests/APItests/NetworkApiTest.cs
+++ b/TMdbEasy Tests/APItests/NetworkApiTest.cs
@@ -19,10 +19,8 @@ namespace TMdbEasy_Tests.APItests
             [TestCase(296096321)]
             public void IncorrectId_ThrowsException(int id)
             {
-                //arrange
-                var obj = new SUT.EasyClient(Constants.ValidApiKey);
-                var d = obj.GetApi<INetworksApi>().Value;
-                //assert
+                var d = Constants.SecureTestClient.GetApi<INetworksApi>().Value;
+
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Other.Network nt = d.GetDetailsAsync(id).Result; });
             }
         }

--- a/TMdbEasy Tests/APItests/ReviewApiTest.cs
+++ b/TMdbEasy Tests/APItests/ReviewApiTest.cs
@@ -20,7 +20,7 @@ namespace TMdbEasy_Tests.APItests
             public void IncorrectId_ThrowsException(int id)
             {
                 //arrange
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var obj = new SUT.EasyClient(Constants.ValidApiKey);
                 var d = obj.GetApi<IReviewApi>().Value;
                 //assert
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Other.Reviews cr = d.GetDetailsAsync(id).Result; });

--- a/TMdbEasy Tests/APItests/ReviewApiTest.cs
+++ b/TMdbEasy Tests/APItests/ReviewApiTest.cs
@@ -19,10 +19,8 @@ namespace TMdbEasy_Tests.APItests
             [TestCase(296096321)]
             public void IncorrectId_ThrowsException(int id)
             {
-                //arrange
-                var obj = new SUT.EasyClient(Constants.ValidApiKey);
-                var d = obj.GetApi<IReviewApi>().Value;
-                //assert
+                var d = Constants.SecureTestClient.GetApi<IReviewApi>().Value;
+
                 Assert.Throws<AggregateException>(() => { SUT.TmdbObjects.Other.Reviews cr = d.GetDetailsAsync(id).Result; });
             }
         }

--- a/TMdbEasy Tests/Constants.cs
+++ b/TMdbEasy Tests/Constants.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace TMdbEasy_Tests
+{
+    internal static class Constants
+    {
+        public const string ValidApiKey = "6d4b546936310f017557b2fb498b370b";
+    }
+}

--- a/TMdbEasy Tests/Constants.cs
+++ b/TMdbEasy Tests/Constants.cs
@@ -1,9 +1,16 @@
-﻿using System;
+﻿using TMdbEasy;
 
 namespace TMdbEasy_Tests
 {
     internal static class Constants
     {
         public const string ValidApiKey = "6d4b546936310f017557b2fb498b370b";
+
+        public static readonly EasyClient SecureTestClient;
+
+        static Constants()
+        {
+            SecureTestClient = new EasyClient(ValidApiKey);
+        }
     }
 }

--- a/TMdbEasy Tests/RequestEngineTest.cs
+++ b/TMdbEasy Tests/RequestEngineTest.cs
@@ -56,12 +56,11 @@ namespace TMdbEasy_Tests
             [TestCase(296096)]
             public async Task CorrectQuery_DoesNotReturnNull(int id)
             {
-                //arrange
-                var obj = new SUT.EasyClient(Constants.ValidApiKey);
-                var d = obj.GetApi<IMovieApi>().Value;
+                var d = Constants.SecureTestClient.GetApi<IMovieApi>().Value;
+
                 //act
                 SUT.TmdbObjects.Movies.MovieFullDetails mov = await d.GetDetailsAsync(id).ConfigureAwait(false);
-                //assert
+
                 Assert.IsNotNull(mov);
             }
         }

--- a/TMdbEasy Tests/RequestEngineTest.cs
+++ b/TMdbEasy Tests/RequestEngineTest.cs
@@ -26,7 +26,7 @@ namespace TMdbEasy_Tests
                 Assert.Throws<Exception>(() => new SUT.EasyClient(_apikey));
             }
 
-            [TestCase("6d4b546936310f017557b2fb498b370b")]
+            [TestCase(Constants.ValidApiKey)]
             public void SecuredParam_AssignsSecureUrl(string _apikey, bool secure = true)
             {
                 //Arrange
@@ -37,7 +37,7 @@ namespace TMdbEasy_Tests
                 Assert.AreEqual(SUT.REngine.Url, "https://api.themoviedb.org/3/");
             }
 
-            [TestCase("6d4b546936310f017557b2fb498b370b", false)]
+            [TestCase(Constants.ValidApiKey, false)]
             public void UnSecuredParam_AssignsUnsecureUrl(string _apikey, bool secure = false)
             {
                 //Arrange
@@ -57,7 +57,7 @@ namespace TMdbEasy_Tests
             public async Task CorrectQuery_DoesNotReturnNull(int id)
             {
                 //arrange
-                var obj = new SUT.EasyClient("6d4b546936310f017557b2fb498b370b");
+                var obj = new SUT.EasyClient(Constants.ValidApiKey);
                 var d = obj.GetApi<IMovieApi>().Value;
                 //act
                 SUT.TmdbObjects.Movies.MovieFullDetails mov = await d.GetDetailsAsync(id).ConfigureAwait(false);

--- a/TMdbEasy Tests/TMdbEasy Tests.csproj
+++ b/TMdbEasy Tests/TMdbEasy Tests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="APItests\MovieApiTest.cs" />
     <Compile Include="APItests\NetworkApiTest.cs" />
     <Compile Include="APItests\ReviewApiTest.cs" />
+    <Compile Include="Constants.cs" />
     <Compile Include="RequestEngineTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
- Replaces hard-coded API key from Integration tests with a const
- Moves EasyClient initialization to the Constants class
  (*to increase performance because every EasyClient initialization is a live API call because of the API key validation*)

I made a test to test how many times the Constants class will be initialized and it happened only once.

The last commit is decreased the test time about 3sec (from 7-8 to 5sec)